### PR TITLE
bck_exercise6

### DIFF
--- a/training-sfcc-sfra-develop/cartridges/app_storefront_custom/cartridge/scripts/job/exercise6.js
+++ b/training-sfcc-sfra-develop/cartridges/app_storefront_custom/cartridge/scripts/job/exercise6.js
@@ -1,0 +1,58 @@
+'use strict';
+
+var File = require('dw/io/File');
+var FileWriter = require('dw/io/FileWriter');
+var logger = require('dw/system/Logger');
+var XMLStreamWriter = require('dw/io/XMLIndentingStreamWriter');
+var ProductMgr = require('dw/catalog/ProductMgr');
+
+/**
+ * generate a new catalog file which assigns the products which belongs to a particular brand to a category
+ * @param {string} args - the parameters sent by a job
+ */
+function generateCatalogFile(args) {
+
+    var catalogPath = File.TEMP + File.SEPARATOR + "exercise6Catalog.xml";
+    var catalogFile = new File(catalogPath);
+    var fileWriter = new FileWriter(catalogFile,'UTF-8');
+    var xmlSW = new XMLStreamWriter(fileWriter);
+    try {
+        // Create the XML
+        xmlSW.writeStartDocument("UTF-8", "1.0");
+        xmlSW.writeStartElement('catalog');
+        xmlSW.writeAttribute('xmlns', 'http://www.demandware.com/xml/impex/catalog/2006-10-31');
+        xmlSW.writeAttribute('catalog-id', 'storefront-catalog-m-en');
+        // Get the parameter brand from the job
+        var brand = args.get('brand');
+        // Get the products with a brand defined
+        var products = ProductMgr.queryAllSiteProducts();
+        while (products.hasNext()) {
+            var product = products.next();
+            if (product.brand == brand) {
+                // Create an element
+                xmlSW.writeStartElement('category-assignment');
+                // Include the product in the category electronics-game-consoles
+                xmlSW.writeAttribute('category-id','electronics-game-consoles');
+                xmlSW.writeAttribute('product-id',product.ID);
+                xmlSW.writeStartElement('primary-flag');
+                xmlSW.writeCharacters('true');
+                xmlSW.writeEndElement();
+                xmlSW.writeEndElement();
+            }
+        }
+        // Closing the XML
+        xmlSW.writeEndElement();
+        xmlSW.writeEndDocument();
+    } catch (error) {
+        logger.error('ERROR!! >> ' + error)
+    } finally {
+        xmlSW.flush();
+        filewriter.flush();
+        xmlSW.close();
+        fileWriter.close();
+    }
+}
+
+module.exports = {
+    generateCatalogFile: generateCatalogFile
+};

--- a/training-sfcc-sfra-develop/metadata/jobs.xml
+++ b/training-sfcc-sfra-develop/metadata/jobs.xml
@@ -1,5 +1,28 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <jobs xmlns="http://www.demandware.com/xml/impex/jobs/2015-07-01">
+    <job job-id="bckExercise6" priority="0">
+        <description>Job created for the backend exercise 6</description>
+        <parameters/>
+        <flow>
+            <context site-id="RefArch"/>
+            <step step-id="bckExercise6" type="ExecuteScriptModule" enforce-restart="false">
+                <description/>
+                <parameters>
+                    <parameter name="ExecuteScriptModule.Module">app_storefront_custom/cartridge/scripts/job/exercise6.js</parameter>
+                    <parameter name="ExecuteScriptModule.FunctionName">generateCatalogFile</parameter>
+                    <parameter name="ExecuteScriptModule.Transactional">false</parameter>
+                    <parameter name="brand">guess</parameter>
+                </parameters>
+            </step>
+        </flow>
+        <rules/>
+        <triggers>
+            <run-once enabled="false">
+                <date>2021-04-27Z</date>
+                <time>08:02:04.000Z</time>
+            </run-once>
+        </triggers>
+    </job>
     <job job-id="RebuildURLs" priority="0">
         <description/>
         <parameters/>


### PR DESCRIPTION
2 modifications made for backend exercise 6:
1) the script exercise6.js where a new xml file is contaning the new association between products with brand "guess" and a category
2) the definition of the new job (bckExercise6) which invokes the script to generate the xml file

Attached demostration images:
- Adding value to the "brand" property of a particular product
<img width="1046" alt="2021-04-27_18h03_10" src="https://user-images.githubusercontent.com/80473270/116275484-f7825400-a783-11eb-980b-66b14851dbb3.png">

- the script is configured to create and store the XML file in the Web DAV TEMP folder
<img width="1889" alt="2021-04-27_17h56_11" src="https://user-images.githubusercontent.com/80473270/116275587-0f59d800-a784-11eb-85f8-1e59f9ab0838.png">

- The content of the file:
<img width="605" alt="2021-04-27_17h56_42" src="https://user-images.githubusercontent.com/80473270/116275763-30bac400-a784-11eb-80e1-ad981bf856b5.png">


